### PR TITLE
RDKE-140: Create Application layer manifest for RPi

### DIFF
--- a/raspberrypi4-64.xml
+++ b/raspberrypi4-64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote fetch="ssh://gerrit.teamccp.com:29418" name="rdkgerritt" />
     <remote fetch="ssh://git@github.com/rdk-e" name="rdke" review="https://github.com/rdk-e"/>
+    <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral"/>
     <remote fetch="https://code.rdkcentral.com/r/a/" name="cmf" review="https://code.rdkcentral.com/r/a/" />
 
     <project groups="buildscripts" name="build-scripts" path="scripts" remote="rdke" revision="refs/tags/2.0.4">

--- a/raspberrypi4-64.xml
+++ b/raspberrypi4-64.xml
@@ -1,72 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="ssh://gerrit.teamccp.com:29418" name="rdkgerritt" />
-  <remote fetch="ssh://git@github.com/rdk-e" name="rdke" review="https://github.com/rdk-e"/>
-  <remote fetch="https://code.rdkcentral.com/r/a/" name="cmf" review="https://code.rdkcentral.com/r/a/" />
+    <remote fetch="ssh://gerrit.teamccp.com:29418" name="rdkgerritt" />
+    <remote fetch="ssh://git@github.com/rdk-e" name="rdke" review="https://github.com/rdk-e"/>
+    <remote fetch="https://code.rdkcentral.com/r/a/" name="cmf" review="https://code.rdkcentral.com/r/a/" />
 
-  <project groups="buildscripts" name="build-scripts" path="scripts" remote="rdke" revision="refs/tags/2.0.4">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_SCRIPTS"/>
-  </project>
+    <project groups="buildscripts" name="build-scripts" path="scripts" remote="rdke" revision="refs/tags/2.0.4">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_SCRIPTS"/>
+    </project>
 
-  <project groups="imagebuilder" name="meta-image-builder" path="rdke/common/meta-image-support" remote="rdke" revision="feature/rpi-open-platform-integration">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_IMAGE_SUPPORT"/>
-  </project>
+    <project groups="imagebuilder" name="meta-image-builder" path="rdke/common/meta-image-support" remote="rdke" revision="feature/rpi-open-platform-integration">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_IMAGE_SUPPORT"/>
+    </project>
   
-  <project groups="configs" name="rdke-common-config" path="rdke/configs/common" remote="rdke" revision="refs/tags/1.0.8">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_CONFIG"/>
-  </project>
+    <project groups="configs" name="rdke-common-config" path="rdke/configs/common" remote="rdke" revision="refs/tags/1.0.8">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_CONFIG"/>
+    </project>
   
-  <project groups="configs" name="rdke-tv-config" path="rdke/configs/profile" remote="rdke" revision="refs/tags/1.0.1">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PROFILE_CONFIG"/>
-  </project>  
+    <project groups="configs" name="rdke-stb-config" path="rdke/configs/profile" remote="rdke" revision="refs/tags/1.0.1">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PROFILE_CONFIG"/>
+    </project>
 
-  <project groups="products" name="meta-product-raspberrypi" path="rdke/product/meta-raspberrypi4" remote="rdkcentral" revision="refs/tags/1.0.4">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PRODUCT_LAYER" />
-  <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_IS_OPEN_SOURCE" />
-  </project>
+    <project groups="layers" name="meta-oss-reference-release" path="rdke/common/meta-oss-reference-release" remote="rdke" revision="refs/tags/3.0.3">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_RELEASE"/>
+    </project>
+  
+    <project groups="oss" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdke" revision="refs/tags/3.0.3" >
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_OSS_REFERENCE"/>
+    </project>
+
+    <project groups="oe" name="meta-openembedded" path="rdke/common/meta-openembedded" remote="rdke" revision="refs/tags/v1.0.0_dunfell" >
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OPENEMBEDDED"/>
+    </project>
+
+    <project groups="oe" name="poky" path="rdke/common/poky" remote="rdke" revision="feature/RDK-50635-Fix-broken-dev-dependency-pkg-config" >
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_POKY"/>
+    </project>
+
+    <project groups="layers" name="meta-foundation-release" path="rdke/foundation/meta-foundation-release" remote="rdke" revision="refs/tags/2.0.4">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_FOUNDATION_RELEASE"/>
+    </project>
+
+    <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="feature/rpi-open-platform-integration">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
+    </project>
+  
+    <project groups="products" name="meta-product-raspberrypi" path="rdke/product/meta-raspberrypi4" remote="rdkcentral" revision="refs/tags/1.0.4">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PRODUCT_LAYER" />
+        <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_IS_OPEN_SOURCE" />
+    </project>
  
-  <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral" revision="refs/tags/1.1.0">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_VENDOR_RELEASE" />
-  </project>
+    <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral" revision="refs/tags/1.1.0">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_VENDOR_RELEASE" />
+    </project>
 
-  <project groups="imageassembler" name="meta-image-assembler-generic" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="develop">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_IMAGES"/>
-  </project>
+    <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="develop">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
+        <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_APPLICATION_DEVELOPMENT"/>
+    </project>
 
-  <project groups="oss" name="meta-oss-core-boot" path="rdke/common/meta-oss-core-boot" remote="rdke" revision="refs/tags/v1.0.0" >
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_CORE_BOOT"/>
-  </project>
-
-  <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="develop">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
-  <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_APPLICATION_DEVELOPMENT"/>
-  </project>
-
-  <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="feature/rpi-open-platform-integration">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
-  </project>
-
-  <project groups="layers" name="meta-foundation-release" path="rdke/foundation/meta-foundation-release" remote="rdke" revision="refs/tags/2.0.4">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_FOUNDATION_RELEASE"/>
-  </project>
-
-  <project groups="layers" name="meta-oss-reference-release" path="rdke/common/meta-oss-reference-release" remote="rdke" revision="refs/tags/3.0.3">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_RELEASE"/>
-  </project>
-  
-  <project groups="oss" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdke" revision="refs/tags/3.0.3" >
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_OSS_REFERENCE"/>
-  </project>
-
-  <project groups="oe" name="meta-openembedded" path="rdke/common/meta-openembedded" remote="rdke" revision="refs/tags/v1.0.0_dunfell" >
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OPENEMBEDDED"/>
-  </project>
-
-  <project groups="oe" name="poky" path="rdke/common/poky" remote="rdke" revision="feature/RDK-50635-Fix-broken-dev-dependency-pkg-config" >
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_POKY"/>
-  </project>
-  
-  <project groups="oe" name="meta-python2" path="rdke/common/meta-python2" remote="rdke" revision="refs/tags/GRT_v2" />
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
-  </project>
 </manifest>

--- a/raspberrypi4-64.xml
+++ b/raspberrypi4-64.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote fetch="ssh://gerrit.teamccp.com:29418" name="rdkgerritt" />
+  <remote fetch="ssh://git@github.com/rdk-e" name="rdke" review="https://github.com/rdk-e"/>
+  <remote fetch="https://code.rdkcentral.com/r/a/" name="cmf" review="https://code.rdkcentral.com/r/a/" />
+
+  <project groups="buildscripts" name="build-scripts" path="scripts" remote="rdke" revision="refs/tags/2.0.4">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_SCRIPTS"/>
+  </project>
+
+  <project groups="imagebuilder" name="meta-image-builder" path="rdke/common/meta-image-support" remote="rdke" revision="feature/rpi-open-platform-integration">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_IMAGE_SUPPORT"/>
+  </project>
+  
+  <project groups="configs" name="rdke-common-config" path="rdke/configs/common" remote="rdke" revision="refs/tags/1.0.8">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_CONFIG"/>
+  </project>
+  
+  <project groups="configs" name="rdke-tv-config" path="rdke/configs/profile" remote="rdke" revision="refs/tags/1.0.1">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PROFILE_CONFIG"/>
+  </project>  
+
+  <project groups="products" name="meta-product-raspberrypi" path="rdke/product/meta-raspberrypi4" remote="rdkcentral" revision="refs/tags/1.0.4">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PRODUCT_LAYER" />
+  <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_IS_OPEN_SOURCE" />
+  </project>
+ 
+  <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral" revision="refs/tags/1.1.0">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_VENDOR_RELEASE" />
+  </project>
+
+  <project groups="imageassembler" name="meta-image-assembler-generic" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="feature/rpi-open-platform-integration">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_IMAGES"/>
+  </project>
+
+  <project groups="oss" name="meta-oss-core-boot" path="rdke/common/meta-oss-core-boot" remote="rdke" revision="refs/tags/v1.0.0" >
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_CORE_BOOT"/>
+  </project>
+
+  <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="feature/rpi-open-platform-integration">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
+  <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_APPLICATION_DEVELOPMENT"/>
+  </project>
+
+  <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="feature/rpi-open-platform-integration">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
+  </project>
+
+  <project groups="layers" name="meta-foundation-release" path="rdke/foundation/meta-foundation-release" remote="rdke" revision="refs/tags/2.0.4">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_FOUNDATION_RELEASE"/>
+  </project>
+
+  <project groups="layers" name="meta-oss-reference-release" path="rdke/common/meta-oss-reference-release" remote="rdke" revision="refs/tags/3.0.3">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_RELEASE"/>
+  </project>
+  
+  <project groups="oss" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdke" revision="refs/tags/3.0.3" >
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_OSS_REFERENCE"/>
+  </project>
+
+  <project groups="oe" name="meta-openembedded" path="rdke/common/meta-openembedded" remote="rdke" revision="refs/tags/v1.0.0_dunfell" >
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OPENEMBEDDED"/>
+  </project>
+
+  <project groups="oe" name="poky" path="rdke/common/poky" remote="rdke" revision="feature/RDK-50635-Fix-broken-dev-dependency-pkg-config" >
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_POKY"/>
+  </project>
+  
+  <project groups="oe" name="meta-python2" path="rdke/common/meta-python2" remote="rdke" revision="refs/tags/GRT_v2" />
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
+  </project>
+</manifest>

--- a/raspberrypi4-64.xml
+++ b/raspberrypi4-64.xml
@@ -49,7 +49,7 @@
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_IS_OPEN_SOURCE" />
     </project>
  
-    <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral" revision="refs/tags/1.1.0">
+    <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral" revision="refs/tags/1.2.1">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_VENDOR_RELEASE" />
     </project>
 

--- a/raspberrypi4-64.xml
+++ b/raspberrypi4-64.xml
@@ -29,7 +29,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_VENDOR_RELEASE" />
   </project>
 
-  <project groups="imageassembler" name="meta-image-assembler-generic" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="feature/rpi-open-platform-integration">
+  <project groups="imageassembler" name="meta-image-assembler-generic" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="develop">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_IMAGES"/>
   </project>
 
@@ -37,7 +37,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_CORE_BOOT"/>
   </project>
 
-  <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="feature/rpi-open-platform-integration">
+  <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="develop">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_APPLICATION_DEVELOPMENT"/>
   </project>


### PR DESCRIPTION
Reason for change: Add raspberrypi manifest
Test Procedure: Try local build
Risks: Low