### PR TITLE
RDKVREFPLT-3163: application layer manifest update

### DIFF
--- a/raspberrypi4-64.xml
+++ b/raspberrypi4-64.xml
@@ -5,12 +5,12 @@
     <include name="rdk-apps.xml" />
 
     <!-- Platform specific layers -->
-    <project groups="products" name="meta-product-raspberrypi" path="rdke/product/meta-raspberrypi4" remote="rdkcentral-platform" revision="refs/tags/1.0.9">
+    <project groups="products" name="meta-product-raspberrypi" path="rdke/product/meta-product-raspberrypi" remote="rdkcentral-platform" revision="refs/tags/1.1.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PRODUCT_LAYER" />
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_IS_OPEN_SOURCE" />
     </project>
  
-    <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral-platform" revision="refs/tags/1.2.4">
+    <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral-platform" revision="refs/tags/1.2.5">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_VENDOR_RELEASE" />
     </project>
 </manifest>

--- a/rdk-apps.xml
+++ b/rdk-apps.xml
@@ -46,11 +46,12 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_POKY"/>
     </project>
 
-    <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="feature/RDKVREFPLT-3162-mw-1.9.9-aligned-generic-release">
+    <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="e10100d039844a93a5cd2826ba65acf4a438f977">
+        <!-- Use SHA from feature/rpi-open-platform-integration -->
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
     </project>
 
-    <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="feature/RDKVREFPLT-3163-app-layer-update">
+    <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="refs/tags/1.1.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_APPLICATION_DEVELOPMENT"/>
     </project>

--- a/rdk-apps.xml
+++ b/rdk-apps.xml
@@ -50,7 +50,7 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
     </project>
 
-    <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="refs/tags/1.0.1">
+    <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="feature/RDKVREFPLT-3163-app-layer-update">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_APPLICATION_DEVELOPMENT"/>
     </project>

--- a/rdk-apps.xml
+++ b/rdk-apps.xml
@@ -46,7 +46,7 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_POKY"/>
     </project>
 
-    <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="feature/rpi-open-platform-integration">
+    <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="feature/RDKVREFPLT-3162-mw-1.9.9-aligned-generic-release">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
     </project>
 

--- a/rdk-apps.xml
+++ b/rdk-apps.xml
@@ -8,42 +8,48 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_SCRIPTS"/>
     </project>
 
-    <project groups="imagebuilder" name="meta-image-builder" path="rdke/common/meta-image-support" remote="rdke" revision="404b898290b3d11eb07484d8bcc2deab1ac1aaf0">
+    <project groups="buildsupport" name="meta-rdk-auxiliary" path="rdke/common/meta-rdk-auxiliary" remote="rdke" revision="f37760a21a6a656040244fb929d84c3d56551c11">
+        <!-- RDKVREFPLT-3302: Replace with meta-aux layer matching MANIFEST_EXPORT_PATH when its is available -->
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_AUXILIARY"/>
+    </project>
+
+    <project groups="stacklayering" name="meta-stack-layering-support" path="rdke/common/meta-stack-layering-support" remote="rdke" revision="refs/tags/1.3.1">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_STACK_LAYERING_SUPPORT"/>
+    </project>
+
+    <!-- RDKVREFPLT-3302: remove when meta-aux is having the complete generic bbclasses -->
+    <project groups="imagebuilder" name="meta-image-support" path="rdke/common/meta-image-support" remote="rdke" revision="3.0.8">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_IMAGE_SUPPORT"/>
     </project>
-  
+
     <project groups="configs" name="rdke-common-config" path="rdke/configs/common" remote="rdke" revision="refs/tags/1.0.8">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_CONFIG"/>
     </project>
-  
+
     <project groups="configs" name="rdke-stb-config" path="rdke/configs/profile" remote="rdke" revision="refs/tags/1.0.1">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PROFILE_CONFIG"/>
     </project>
 
-    <project groups="layers" name="meta-oss-reference-release" path="rdke/common/meta-oss-reference-release" remote="rdke" revision="refs/tags/3.0.3">
+    <project groups="layers" name="meta-oss-reference-release" path="rdke/common/meta-oss-reference-release" remote="rdke" revision="refs/tags/3.2.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_RELEASE"/>
     </project>
-  
-    <project groups="oss" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdke" revision="refs/tags/3.0.3" >
+
+    <project groups="oss" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdke" revision="refs/tags/3.2.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_OSS_REFERENCE"/>
     </project>
 
-    <project groups="oe" name="meta-openembedded" path="rdke/common/meta-openembedded" remote="rdke" revision="refs/tags/v1.0.0_dunfell" >
+    <project groups="oe" name="meta-openembedded" path="rdke/common/meta-openembedded" remote="rdke" revision="refs/tags/v1.0.0_dunfell">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OPENEMBEDDED"/>
     </project>
 
-    <project groups="oe" name="poky" path="rdke/common/poky" remote="rdke" revision="refs/tags/v1.0.5" >
+    <project groups="oe" name="poky" path="rdke/common/poky" remote="rdke" revision="refs/tags/v1.0.6">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_POKY"/>
-    </project>
-
-    <project groups="layers" name="meta-foundation-release" path="rdke/foundation/meta-foundation-release" remote="rdke" revision="6ae33c7db14739693c924bb388b09c61eb5950a5">
-        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_FOUNDATION_RELEASE"/>
     </project>
 
     <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="feature/rpi-open-platform-integration">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
     </project>
- 
+
     <project groups="layers" name="meta-application-development-generic" path="rdke/application/meta-application-development" remote="rdkcentral" revision="refs/tags/1.0.1">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_APPLICATION_DEVELOPMENT"/>

--- a/rdk-apps.xml
+++ b/rdk-apps.xml
@@ -18,7 +18,7 @@
     </project>
 
     <!-- RDKVREFPLT-3302: remove when meta-aux is having the complete generic bbclasses -->
-    <project groups="imagebuilder" name="meta-image-support" path="rdke/common/meta-image-support" remote="rdke" revision="3.0.8">
+    <project groups="imagebuilder" name="meta-image-support" path="rdke/common/meta-image-support" remote="rdke" revision="refs/tags/3.0.8">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_IMAGE_SUPPORT"/>
     </project>
 


### PR DESCRIPTION
## What's new:
- Update to latest poky(v1.0.6), OSS(v3.2.0), vendor(v1.2.5) and Middleware release(v1.9.9)
- Uses following new tools layer repositories and removed deprecated foundation layer
- -  meta-rdk-auxiliary (develop)
- - meta-stack-layering-support (v1.3.1)
- - meta-image-support (v3.0.8)